### PR TITLE
macports toolchain: update to use python310 (new default)

### DIFF
--- a/install-or-update-macports.sh
+++ b/install-or-update-macports.sh
@@ -42,8 +42,8 @@ fi
 sudo ${BUILD_TOOLS_PREFIX}/bin/port -v selfupdate || die "Could not selfupdate macports"
 
 # Note that docbook-utils is needed for fontconfig docs, but we're skipping it here because of https://trac.macports.org/ticket/62354
-sudo ${BUILD_TOOLS_PREFIX}/bin/port -N -v install autoconf automake pkgconfig libtool py39-mako meson xmlto asciidoc doxygen fop groff gtk-doc || die "Could not install basic toolchain"
-sudo ${BUILD_TOOLS_PREFIX}/bin/port select python3 python39 || die "Could not select python3"
+sudo ${BUILD_TOOLS_PREFIX}/bin/port -N -v -f install autoconf automake pkgconfig libtool py310-mako meson xmlto asciidoc doxygen fop groff gtk-doc || die "Could not install basic toolchain"
+sudo ${BUILD_TOOLS_PREFIX}/bin/port select python3 python310 || die "Could not select python3"
 
 # cmake can mess up the way meson searches for dependnecies, so deactivate it and the rest of the recursive leaves
 sudo ${BUILD_TOOLS_PREFIX}/bin/port deactivate rleaves


### PR DESCRIPTION
avoids multiple python versions being installed

* force installation of ports

avoids cruft issues

(tested to install MacPorts toolchain components -- I have not tested full build of XQuartz with python310 as yet. You may want to wait for this PR until after the upcoming release).