### PR TITLE
install-or-update-macports.sh: add setuptools to needed ports

### DIFF
--- a/install-or-update-macports.sh
+++ b/install-or-update-macports.sh
@@ -15,7 +15,7 @@ BUILD_TOOLS_PREFIX_STD="/opt/buildX11"
 BUILD_TOOLS_PREFIX_CMAKE="/opt/buildX11-cmake"
 
 # Note that docbook-utils is needed for fontconfig docs, but we're skipping it here because of https://trac.macports.org/ticket/62354
-PORTS_STD="autoconf automake pkgconfig libtool py313-mako meson xmlto asciidoc doxygen fop groff gtk-doc graphviz"
+PORTS_STD="autoconf automake pkgconfig libtool py313-mako py313-setuptools meson xmlto asciidoc doxygen fop groff gtk-doc graphviz"
 PORTS_CMAKE="cmake"
 
 BASE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"


### PR DESCRIPTION
no longer installed by default with python 3.12+
required for mesa to build

fixes:

Running command: /opt/buildX11/bin/python3 -c '
from distutils.version import StrictVersion
import mako
assert StrictVersion(mako.__version__) > StrictVersion("0.8.0")
  '
--- stdout ---

--- stderr ---
Traceback (most recent call last):
  File "<string>", line 2, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'

meson.build:1018:2: ERROR: Problem encountered: Python (3.x) mako module >= 0.8.0 required to build mesa.