### PR TITLE
add a gitignore for libXt7-stub artifacts

### DIFF
--- a/src/xorg/lib/libXt7-stub/.gitignore
+++ b/src/xorg/lib/libXt7-stub/.gitignore
@@ -1,0 +1,78 @@
+#
+#		X.Org module default exclusion patterns
+#		The next section if for module specific patterns
+#
+#	Do not edit the following section
+# 	GNU Build System (Autotools)
+aclocal.m4
+autom4te.cache/
+autoscan.log
+ChangeLog
+compile
+config.guess
+config.h
+config.h.in
+config.log
+config-ml.in
+config.py
+config.status
+config.status.lineno
+config.sub
+configure
+configure.scan
+depcomp
+.deps/
+INSTALL
+install-sh
+.libs/
+libtool
+libtool.m4
+ltmain.sh
+lt~obsolete.m4
+ltoptions.m4
+ltsugar.m4
+ltversion.m4
+Makefile
+Makefile.in
+mdate-sh
+missing
+mkinstalldirs
+*.pc
+py-compile
+stamp-h?
+symlink-tree
+texinfo.tex
+ylwrap
+
+#	Do not edit the following section
+# 	Edit Compile Debug Document Distribute
+*~
+*.[0-9]
+*.[0-9]x
+*.bak
+*.bin
+core
+*.dll
+*.exe
+*-ISO*.bdf
+*-JIS*.bdf
+*-KOI8*.bdf
+*.kld
+*.ko
+*.ko.cmd
+*.lai
+*.l[oa]
+*.[oa]
+*.obj
+*.patch
+*.so
+*.pcf.gz
+*.pdb
+*.tar.bz2
+*.tar.gz
+#
+#		Add & Override patterns for libXt7-stub
+#
+#		Edit the following section as needed
+# For example, !report.pc overrides *.pc. See 'man gitignore'
+#


### PR DESCRIPTION
avoids:

```
 % git status
On branch add_llvm_build
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	src/xorg/lib/libXt7-stub/.deps/
	src/xorg/lib/libXt7-stub/.libs/
	src/xorg/lib/libXt7-stub/Makefile
	src/xorg/lib/libXt7-stub/Makefile.in
	src/xorg/lib/libXt7-stub/aclocal.m4
	src/xorg/lib/libXt7-stub/autom4te.cache/
	src/xorg/lib/libXt7-stub/compile
	src/xorg/lib/libXt7-stub/config.guess
	src/xorg/lib/libXt7-stub/config.h
	src/xorg/lib/libXt7-stub/config.h.in
	src/xorg/lib/libXt7-stub/config.log
	src/xorg/lib/libXt7-stub/config.status
	src/xorg/lib/libXt7-stub/config.sub
	src/xorg/lib/libXt7-stub/configure
	src/xorg/lib/libXt7-stub/depcomp
	src/xorg/lib/libXt7-stub/install-sh
	src/xorg/lib/libXt7-stub/libXt.la
	src/xorg/lib/libXt7-stub/libtool
	src/xorg/lib/libXt7-stub/ltmain.sh
	src/xorg/lib/libXt7-stub/m4/libtool.m4
	src/xorg/lib/libXt7-stub/m4/ltoptions.m4
	src/xorg/lib/libXt7-stub/m4/ltsugar.m4
	src/xorg/lib/libXt7-stub/m4/ltversion.m4
	src/xorg/lib/libXt7-stub/m4/lt~obsolete.m4
	src/xorg/lib/libXt7-stub/missing
	src/xorg/lib/libXt7-stub/stamp-h1
	src/xorg/lib/libXt7-stub/stub.lo
```