### PR TITLE
libXt-flatnamespace: patch for C23 'true' keyword conflict

### DIFF
--- a/src/xorg/lib/libXt-flatnamespace.patches/c23-true-keyword.patch
+++ b/src/xorg/lib/libXt-flatnamespace.patches/c23-true-keyword.patch
@@ -1,0 +1,18 @@
+In C23, 'true' is a keyword, not just a macro from <stdbool.h>. Rename the
+local variable 'true' in _XtShellAncestorSensitive() to avoid the conflict.
+
+diff --git a/src/Shell.c b/src/Shell.c
+index f160527..7d686ee 100644
+--- a/src/Shell.c
++++ b/src/Shell.c
+@@ -961,8 +961,8 @@ void _XtShellAncestorSensitive(
+     int closure,
+     XrmValue *value)
+ {
+-   static Boolean true = True;
+-   if (widget->core.parent == NULL) value->addr = (XPointer)(&true);
++   static Boolean xtrue = True;
++   if (widget->core.parent == NULL) value->addr = (XPointer)(&xtrue);
+    else _XtCopyFromParent (widget,closure,value);
+ }
+ 


### PR DESCRIPTION
autotools now defaults to c23 builds if the compiler supports it macports has updated autotools to the new version, so these builds are now using C23

In C23, 'true' is a keyword, so it cannot be used as a variable name. Rename the local variable in _XtShellAncestorSensitive() to 'xtrue'.