### PR TITLE
Tune optimizations and enable AArch64 NEON

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -107,8 +107,8 @@ elif [ "${APPLICATION_VERSION_STRING}" != "${APPLICATION_VERSION_STRING/beta/}" 
 #    SANITIZER_CFLAGS="-fsanitize=address"
 #    SANITIZER_LIBS="libclang_rt.asan_osx_dynamic.dylib"
 
-    # Beta builds use full stack protection and disable optimizations
-    OPT_CFLAGS="-O0 -fno-optimize-sibling-calls -fno-omit-frame-pointer"
+    # Beta builds use full stack protection. Optimized (-O2) so perf tracks release.
+    OPT_CFLAGS="-O2 -fno-omit-frame-pointer"
     HARDENING_CFLAGS="-fstack-protector-all"
     export MACOSX_DEPLOYMENT_TARGET=10.13
 else

--- a/src/pixman.confopt
+++ b/src/pixman.confopt
@@ -1,3 +1,3 @@
 -Dmmx=disabled \
--Da64-neon=disabled \
+-Da64-neon=enabled \
 -Dtests=disabled


### PR DESCRIPTION
Adjust beta build flags to use `-O2` while keeping frame pointers and full stack protection so beta performance better matches release builds. Also enable Pixman `a64-neon` support to use ARM64 NEON acceleration. Especially the latter seems to improve some performance items by 7x-8x.